### PR TITLE
Add useSurfaceProducer to AngleOptions

### DIFF
--- a/flutter_angle/android/src/main/java/org/fluttergl/flutter_angle/FlutterAnglePlugin.java
+++ b/flutter_angle/android/src/main/java/org/fluttergl/flutter_angle/FlutterAnglePlugin.java
@@ -218,6 +218,7 @@ public class FlutterAnglePlugin implements FlutterPlugin, MethodCallHandler {
     Map<String, Object> arguments = (Map<String, Object>) call.arguments;
     int width = (int) arguments.get("width");
     int height = (int) arguments.get("height");
+    boolean useSurfaceProducer = (boolean) arguments.get("useSurfaceProducer");
 
     if (width <= 0) {
       result.error("no texture width", "no texture width", 0);
@@ -228,10 +229,8 @@ public class FlutterAnglePlugin implements FlutterPlugin, MethodCallHandler {
       return;
     }
     FlutterGLTexture texture;
-    try {
-      // Try to use the new SurfaceProducer API first
-      boolean useSurfaceProducer = true;
 
+    try {
       if (useSurfaceProducer) {
         // Use the new API
         TextureRegistry.SurfaceProducer producer = textureRegistry.createSurfaceProducer();
@@ -284,13 +283,12 @@ public class FlutterAnglePlugin implements FlutterPlugin, MethodCallHandler {
       Map<String, Object> args = (Map<String, Object>) call.arguments;
       int width = (int) args.get("width");
       int height = (int) args.get("height");
+      boolean useSurfaceProducer = (boolean) arguments.get("useSurfaceProducer");
+
       if (width <= 0 || height <= 0) {
         result.error("Invalid dimensions", "Width and height must be positive", null);
         return;
       }
-      
-      // Try to use the new SurfaceProducer API first
-      boolean useSurfaceProducer = true;
       
       GLTexture texture;
       if (useSurfaceProducer) {

--- a/flutter_angle/lib/desktop/angle.dart
+++ b/flutter_angle/lib/desktop/angle.dart
@@ -308,11 +308,12 @@ class FlutterAngle {
     final textureTarget = GL_TEXTURE_2D;
     final height = (options.height*options.dpr).toInt();
     final width = (options.width*options.dpr).toInt();
+
     late final dynamic result;
     if (_useAngle){
-      result = await _channel.invokeMethod('createTextureAngle', {"width": width, "height": height,});
+      result = await _channel.invokeMethod('createTextureAngle', {"width": width, "height": height, "useSurfaceProducer": options.useSurfaceProducer,});
     } else {
-      result = await _channel.invokeMethod('createTexture', {"width": width, "height": height,});
+      result = await _channel.invokeMethod('createTexture', {"width": width, "height": height, "useSurfaceProducer": options.useSurfaceProducer,});
     }
 
     if (Platform.isAndroid) {

--- a/flutter_angle/lib/shared/options.dart
+++ b/flutter_angle/lib/shared/options.dart
@@ -1,17 +1,19 @@
-class AngleOptions{
-  AngleOptions({
+class AngleOptions {
+  final int width;
+  final int height;
+  final double dpr;
+  final bool antialias;
+  final bool alpha;
+  final bool customRenderer;
+  final bool useSurfaceProducer;
+
+  const AngleOptions({
     required this.width,
     required this.height,
     required this.dpr,
     this.alpha = false,
     this.antialias = false,
     this.customRenderer = true,
+    this.useSurfaceProducer = false,
   });
-
-  int width;
-  int height;
-  double dpr;
-  bool antialias;
-  bool alpha;
-  bool customRenderer;
 }

--- a/flutter_angle_native_array/pubspec.yaml
+++ b/flutter_angle_native_array/pubspec.yaml
@@ -1,10 +1,10 @@
 name: flutter_angle_native_array
 description: "A type cast array simular to js."
 version: 0.0.1
-homepage:
+homepage: https://github.com/Knightro63/flutter_angle/tree/main/flutter_angle
 
 environment:
-  sdk: ^3.7.0
+  sdk: ">=3.3.2 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
The usage of surface producer leads to unstable behaviour. Some of the animations are junky and unpredictable.