### PR TITLE
fix android initOpenGLAngle isEmulator

### DIFF
--- a/flutter_angle/android/src/main/java/org/fluttergl/flutter_angle/FlutterAnglePlugin.java
+++ b/flutter_angle/android/src/main/java/org/fluttergl/flutter_angle/FlutterAnglePlugin.java
@@ -300,6 +300,7 @@ public class FlutterAnglePlugin implements FlutterPlugin, MethodCallHandler {
     Map<String, Object> response = new HashMap<>();
     response.put("context", getCurrentContext());
     response.put("dummySurface", dummySurface);
+    response.put("isEmulator", EmulatorDetector.isEmulator());
     result.success(response);
     Log.i(TAG, "ANGLE OpenGL initialized successfully");
   }


### PR DESCRIPTION
The following parameters were missed when initializing the android platform, causing init to fail to run