### PR TITLE
we want to change the makelist.

### DIFF
--- a/flutter_angle/android/src/main/cpp/CMakeLists.txt
+++ b/flutter_angle/android/src/main/cpp/CMakeLists.txt
@@ -44,4 +44,4 @@ target_link_libraries(angle_android_graphic_jni
 # Set output directory
 set_target_properties(angle_android_graphic_jni PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}
-    LINK_FLAGS "-Wl,-z,max-page-size=16384")
+    PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Reason:
Google request the app and library using 16k page size at Android 35 ,  but we find libangle_android_graphic_jni.so is using 4k page size.so we need to change the makelist.

16k page size knoledge:
 https://developer.android.google.cn/guide/practices/page-sizes?hl=nl#cmake_1
blog: https://juejin.cn/post/7396306532671094793

analyze result:
we use three_js package -> three_js_math -> flutter_angle.
flutter_angle will create 3 libs, they are 
libEGL_angle.so (ok)
libGLESv2_angle.so (ok)
libangle_android_graphic_jni.so (failed)

change:
we change the makelist, but it is not ok, and page size is also 4k. so we need you help.
thanks a lot.
---------------------------------------------------------
中文说明概要：
Google要求Android35版本中支持16k对齐，我在项目中的使用了three_js这个库，但是发现该库生成的so文件不符合16k对齐要求。我参考了官方和其它人的博客修改库中编译so文件的cmakelist，但是没有效果。我把我的修改提交PR给您，期待您能帮忙修改此问题。让这个库生成的so文件符合16k对齐的要求。

以上，谢谢！
