### PR TITLE
fix: wrapped native deinit in try-catch to avoid UnsatisfiedLinkError

### DIFF
--- a/flutter_angle/android/src/main/java/org/fluttergl/flutter_angle/FlutterAnglePlugin.java
+++ b/flutter_angle/android/src/main/java/org/fluttergl/flutter_angle/FlutterAnglePlugin.java
@@ -356,8 +356,13 @@ public class FlutterAnglePlugin implements FlutterPlugin, MethodCallHandler {
     }
     flutterTextureMap.clear();
 
-    // Deinitialize native ANGLE resources
-    deinit();
+    try {
+      // Deinitialize native ANGLE resources
+      deinit();
+    }
+    catch (Exception e) {
+      Log.e(TAG, "Error deinitializing native ANGLE resources", e);
+    }
   }
 
   // --- Native methods (used for ANGLE calls) ---


### PR DESCRIPTION
We cannot understand the causes of the error. It happens randomly on a large base of devices, mainly in the background, when the library is deinitialized.

We observe that in the initialization code there is indeed a try/catch, so we believe it is possible that the library does not initialize correctly and consequently, when it performs the onDetach, it fails and crashes. This error is related to the issue https://github.com/Knightro63/flutter_angle/issues/39