### PR TITLE
Support for shared pointers in C++ layer

### DIFF
--- a/flutter_angle/lib/native-array/base_native_array.dart
+++ b/flutter_angle/lib/native-array/base_native_array.dart
@@ -39,7 +39,8 @@ abstract class NativeArray<T extends num> {
   int get BYTES_PER_ELEMENT => oneByteSize;
   
   bool disposed = false;
-
+  //Is it a shared pointer in the CPP layer, and does it not need to be released by Dart
+  bool isPointCpp = false;
   get data;
   get toJS;
 

--- a/flutter_angle/lib/native-array/native_array.dart
+++ b/flutter_angle/lib/native-array/native_array.dart
@@ -4,6 +4,9 @@ class Float32Array extends NativeFloat32Array {
   Float32Array(int size) : super(size);
   Float32Array.fromList(List<double> listData) : super.fromList(listData);
 
+  ///from c++ layer shared pointer
+  Float32Array.fromPoint(dynamic pointFloat, int size)
+      : super.fromPoint(pointFloat, size);
   Float32Array clone() {
     var dartList = this.toDartList();
     return Float32Array(dartList.length)..set(dartList);

--- a/flutter_angle/lib/native-array/native_array_app.dart
+++ b/flutter_angle/lib/native-array/native_array_app.dart
@@ -20,7 +20,7 @@ abstract class PlatformNativeArray<T extends num> extends NativeArray<T> {
 
   @override
   void dispose() {
-    if (!disposed) {
+    if (!disposed && !isPointCpp) {
       calloc.free(data);
       disposed = true;
     }
@@ -44,6 +44,12 @@ class NativeFloat32Array extends PlatformNativeArray<double> {
     toDartList().setAll(0, listData);
   }
 
+  ///from c++ layer shared pointer
+  NativeFloat32Array.fromPoint(Pointer<Float> data, int size) : super(size) {
+    _list = data;
+    oneByteSize = sizeOf<Float>();
+    isPointCpp = true;
+  }
   Float32List toDartList() {
     return data.asTypedList(length);
   }

--- a/flutter_angle/lib/native-array/native_array_web.dart
+++ b/flutter_angle/lib/native-array/native_array_web.dart
@@ -48,6 +48,12 @@ class NativeFloat32Array extends PlatformNativeArray<double> {
     oneByteSize = Float32List.bytesPerElement;
   }
 
+  ///from c++ layer shared pointer
+  NativeFloat32Array.fromPoint(Float32List data, int size) : super(size) {
+    _list = data;
+    oneByteSize = Float32List.bytesPerElement;
+    // isPointCpp = true;
+  }
   @override
   NativeFloat32Array clone() {
     return NativeFloat32Array.fromList(_list);


### PR DESCRIPTION
Supports shared pointers in the C++ layer and provides more flexible support for third-party open-source libraries, such as Assimp.If using a third-party parsing model, you only need to use a Dart pointer to point to the native layer, which reduces memory copying.