### PR TITLE
fix(android): add 16KB page size support for Google Play compliance

### DIFF
--- a/flutter_angle/android/build.gradle
+++ b/flutter_angle/android/build.gradle
@@ -39,7 +39,7 @@ android {
          externalNativeBuild {
              cmake {
                  cppFlags '-std=c++14'
-                 arguments "-DANDROID_STL=c++_shared"
+                 arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                  version "3.31.4"
              }
          }


### PR DESCRIPTION
## Problem

Closes #49

`libangle_android_graphic_jni.so` compiled with NDK 27 (or older) defaults to `0x1000` (4KB) PT_LOAD ELF segment alignment. This is incompatible with 16KB-page kernels on Android 15+ devices. Google Play now requires all apps to support 16KB pages by **May 31, 2026**, or distribution will be blocked.

## Root Cause

NDK 27 and older set `max-page-size=4096` as the linker default for aarch64. NDK 28 changed this default to `16384`, but projects still on NDK 27 are affected.

## Fix

Add `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` to the CMake arguments in `build.gradle`. This instructs the NDK linker to emit `0x4000` (16KB) PT_LOAD alignment — fully backward-compatible with 4KB-page devices.

## Verification

Compiled `angle_android_graphic_jni.cpp` directly with NDK 27 clang to confirm:

| Build | PT_LOAD Align | 16KB compatible |
|---|---|---|
| NDK 27, no flag | `0x1000` (4KB) | ❌ |
| NDK 27, with flag | `0x4000` (16KB) | ✅ |
| NDK 28, no flag | `0x4000` (16KB) | ✅ |